### PR TITLE
Correct bcpd paths

### DIFF
--- a/ALPACA/ALPACA.py
+++ b/ALPACA/ALPACA.py
@@ -1412,11 +1412,13 @@ class ALPACALogic(ScriptedLoadableModuleLogic):
       registrationOutput = self.cpd_registration(targetArray, sourceArrayCombined, parameters["CPDIterations"], parameters["CPDTolerance"], parameters["alpha"], parameters["beta"])
       deformed_array, _ = registrationOutput.register()
     else:
-      np.savetxt ('target.txt', targetArray, delimiter=',')
-      np.savetxt ('source.txt', sourceArrayCombined, delimiter=',')
+      targetPath = os.path.join(slicer.app.cachePath,'target.txt')
+      sourcePath = os.path.join(slicer.app.cachePath,'source.txt')
+      np.savetxt (targetPath, targetArray, delimiter=',')
+      np.savetxt (sourcePath, sourceArrayCombined, delimiter=',')
       path = os.path.join(parameters["BCPDFolder"], 'bcpd') 
-      cmd = f'{path} -x target.txt -y source.txt -l{parameters["alpha"]} -b{parameters["beta"]} -g0.1 -K140 -J500 -c1e-6 -p -d7 -e0.3 -f0.3 -ux -N1'
-      subprocess.run(cmd, shell = True, check = True)
+      cmd = f'{path} -x "{targetPath} -y {sourcePath}" -l{parameters["alpha"]} -b{parameters["beta"]} -g0.1 -K140 -J500 -c1e-6 -p -d7 -e0.3 -f0.3 -ux -N1'
+      cp = subprocess.run(cmd, shell = True, check = True,universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
       deformed_array = np.loadtxt('output_y.txt')
       for fl in glob.glob("output*.txt"):
         os.remove(fl)


### PR DESCRIPTION
Explicitly save BCPD input text files to cache and escape possible file path spaces